### PR TITLE
detalles_partida

### DIFF
--- a/app/Http/Controllers/detallesController.php
+++ b/app/Http/Controllers/detallesController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class detallesController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index($id)
+    {
+        return "usaremos este id pa mostrar los datos mas adelante: ".$id;
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function show($id)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function edit($id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  int  $id
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy($id)
+    {
+        //
+    }
+}

--- a/resources/views/sala/detalles-partida-dota2.blade.php
+++ b/resources/views/sala/detalles-partida-dota2.blade.php
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+</head>
+<body>
+	<?php
+
+			$id=$_POST['numerosala'];
+
+
+
+
+	?>
+</body>
+</html>

--- a/resources/views/sala/salas-creadas.blade.php
+++ b/resources/views/sala/salas-creadas.blade.php
@@ -7,8 +7,27 @@
 
 <body>
   <section id="hero"></section>
- aqui se encuentran las salas que el usuario creo
- 
+  <section>
+  	<h1>Salas Dota 2:</h1>
+  	<center>
+  		<?php
+  				$codigoUS=auth()->id();
+  				$salas = DB::table('sala_dota_2')
+                        ->where("codigo_Usuario","=",$codigoUS)
+                        ->get();?>
+
+                 @foreach ($salas as $indivSala) 
+                 	 <table><td>
+						<!--<tr><input type="hidden" name="numeroSala'.$indivSala->id.'" value="'.$indivSala->id.'"></tr>-->
+						<tr><img src="{{$indivSala->logo}}" style="width: 50px; height: 50px;"></tr>
+						<tr>{{$indivSala->nombre_Torneo}}</tr>
+						<form method="post" action="{{ url('/sala/detalles-partida-dota2/'.$indivSala->id) }}">
+								{{ csrf_field() }}
+								<button type="submit">ver detalles</button>
+						</form>
+					</td></table>        		
+                 @endforeach
+</center></section>
 </body>
 </html>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -55,6 +55,12 @@ Route::post('/sala/crearTorneo','App\Http\Controllers\salaController@create')->n
 //recibe los datos desde el controlador equiposdota2Controller@index
 Route::view('/sala/revicion-sala-dota2','sala/revicion-sala-dota2')->name('revicion-sala-dota2');
 
+//recibe el codigo de la sala y presenta los detalles de la partida desde salas-creadas
+Route::post('/sala/detalles-partida-dota2/{id}','App\Http\Controllers\detallesController@index')->name('detalles-sala-dota2');
+Route::view('/sala/detalles-show-dota2','sala/detalles-partida-dota2')->name('detalles-show-dota2');
+
+
+
 
 
 


### PR DESCRIPTION
cambios:
salas-creadas.blade.php - se añadio el codigo necesario para mostrar las partidas creadas por el usuario (solo de dota 2), de acuerdo a eso adaptalo o cambialo para las partidas de wow
web.php - se añadieron 2 nuevas rutas una para la pagina que se direccionara y otra hacia el controlador que leera los datos de la partida de acuerdo al id
añadidos:
detalles-partida-dota2.blade.php - se añadio una nueva vista en donde se presentaran los detalles de las partidas, por ahora solo obtiene el id, no se implementaros las demas funciones porque no es parte de este sprint
detallesController.php - se añadio un controlador para los detalles de la partida